### PR TITLE
Speed up the build of MLIR from source inside of the GitHub Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,6 +39,15 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     
+    - name: Install ccache
+      run: sudo apt-get install -y ccache
+
+    - name: Configure ccache
+      run: |
+        export PATH="/usr/lib/ccache:$PATH"
+        export CC="ccache gcc"
+        export CXX="ccache g++"
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
@@ -48,3 +57,5 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CCACHE_DIR=/tmp/.ccache


### PR DESCRIPTION
Add ccache to speed up the build process in the GitHub Action workflow.

* Add a step to install `ccache` in `.github/workflows/docker-image.yml`.
* Add a step to configure `ccache` in `.github/workflows/docker-image.yml`.
* Modify the `docker/build-push-action@v5` step to use `ccache` in `.github/workflows/docker-image.yml`.

